### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "protobuf"
+description := "Protocol Buffers are language-neutral, platform-neutral extensible mechanisms for serializing structured data."
+gitrepo     := "https://github.com/protocolbuffers/protobuf.git"
+homepage    := "https://protobuf.dev/"
+license     := "BSD-3-Clause"
+version     := 3.10.0 sha256:ffb91e102e8c389fba6fefec948421852979ae655ebb52e69859a6a3f4c5b61b https://github.com/protocolbuffers/protobuf/releases/download/v3.10.0/protobuf-cpp-3.10.0.tar.gz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

